### PR TITLE
don't panic when file doesn't exist

### DIFF
--- a/corediff.go
+++ b/corediff.go
@@ -58,6 +58,10 @@ func saveDB(path string, db hashDB) {
 
 func parseFile(path, relPath string, db hashDB, updateDB bool) (hits []int, lines [][]byte) {
 	fh, err := os.Open(path)
+	if os.IsNotExist(err) {
+		logInfo(warn("file does not exist: " + path))
+		return nil, nil
+	}
 	check(err)
 	defer fh.Close()
 
@@ -133,7 +137,6 @@ func checkPath(root string, db hashDB, args *baseArgs) *walkStats {
 				if shouldHighlight(lines[idx]) {
 					logInfo("  ", grey(fmt.Sprintf("%-5d", idx)), alarm(string(lines[idx])))
 					// fmt.Printf("%s %s\n", grey(fmt.Sprintf("%-5d", idx)), alarm(string(lines[idx])))
-
 				} else if !args.Suspect {
 					logInfo("  ", grey(fmt.Sprintf("%-5d", idx)), string(lines[idx]))
 					// fmt.Printf("%s %s\n", grey(fmt.Sprintf("%-5d", idx)), string(lines[idx]))
@@ -190,11 +193,9 @@ func addPath(root string, db hashDB, args *baseArgs) {
 		return nil
 	})
 	check(err)
-
 }
 
 func main() {
-
 	if restarted, err := selfupdate.UpdateRestart(selfUpdateURL); restarted || err != nil {
 		logVerbose("Restarted new version", restarted, "with error:", err)
 	}

--- a/setup.go
+++ b/setup.go
@@ -44,6 +44,7 @@ var (
 	boldred   = color.New(color.FgHiRed, color.Bold).SprintFunc()
 	grey      = color.New(color.FgHiBlack).SprintFunc()
 	boldwhite = color.New(color.FgHiWhite).SprintFunc()
+	warn      = color.New(color.FgYellow, color.Bold).SprintFunc()
 	alarm     = color.New(color.FgHiWhite, color.BgHiRed, color.Bold).SprintFunc()
 	green     = color.New(color.FgGreen).SprintFunc()
 
@@ -97,7 +98,6 @@ var (
 )
 
 func setup() *baseArgs {
-
 	var err error
 	color.NoColor = false
 


### PR DESCRIPTION
```
mkdir -p /tmp/corediff
ln -s /some/nonexistent/path/.htaccess /tmp/corediff/.htaccess
corediff --ignore-paths /tmp/corediff
```

Before:
```
Corediff 20240219-DEV loaded 2639824 precomputed hashes. (C) 2020-2023 labs@sansec.io
Using database: /Users/daniel/Library/Caches/corediff/6c8f33677d302e1847d8553877dfa6d11d4597d3.urlcache

panic: open /private/tmp/corediff/.htaccess: no such file or directory

goroutine 1 [running]:
main.check(...)
	/Users/daniel/Code/corediff/helpers.go:77
main.parseFile({0x140000182a0?, 0x1002d2d08?}, {0x140000021a0?, 0x300000002?}, 0x140000f7758?, 0x0)
	/Users/daniel/Code/corediff/corediff.go:61 +0x330
main.checkPath.func1({0x140000182a0, 0x1f}, {0x1005a3a20?, 0x140000a8410?}, {0x0?, 0x0})
	/Users/daniel/Code/corediff/corediff.go:127 +0x380
path/filepath.walk({0x140000182a0, 0x1f}, {0x1005a3a20, 0x140000a8410}, 0x140000f7b48)
	/usr/local/go/src/path/filepath/path.go:477 +0xc8
path/filepath.walk({0x140000b43a8, 0x15}, {0x1005a3a20, 0x140000a8340}, 0x140000f7b48)
	/usr/local/go/src/path/filepath/path.go:501 +0x1d4
path/filepath.Walk({0x140000b43a8, 0x15}, 0x140000f7b48)
	/usr/local/go/src/path/filepath/path.go:572 +0x6c
main.checkPath({0x140000b43a8, 0x15}, 0x14000be6150, 0x14000012030)
	/Users/daniel/Code/corediff/corediff.go:90 +0x80
main.main()
	/Users/daniel/Code/corediff/corediff.go:233 +0x4e0
exit status 2
```

After:
```
Corediff 20240219-DEV loaded 2639824 precomputed hashes. (C) 2020-2023 labs@sansec.io
Using database: /Users/daniel/Library/Caches/corediff/6c8f33677d302e1847d8553877dfa6d11d4597d3.urlcache

file does not exist: /private/tmp/corediff/.htaccess

===============================================================================
 Corediff completed scanning 2 files in /private/tmp/corediff
 - Files with unrecognized lines   : 0
 - Files with only recognized lines: 1
 - Files with custom code          : 0
 - Files without code              : 1
```