### PR TITLE
add (optional) path filter

### DIFF
--- a/corediff.go
+++ b/corediff.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/gwillem/go-buildversion"
 	"github.com/gwillem/go-selfupdate"
@@ -104,6 +105,9 @@ func checkPath(root string, db hashDB, args *baseArgs) *walkStats {
 			return nil
 		}
 		if info.IsDir() {
+			return nil
+		}
+		if args.PathFilter != "" && !strings.HasPrefix(relPath, args.PathFilter) {
 			return nil
 		}
 

--- a/setup.go
+++ b/setup.go
@@ -32,6 +32,7 @@ type (
 		Suspect     bool   `short:"s" long:"suspect" description:"Show suspect code lines only."`
 		NoCMS       bool   `long:"no-cms" description:"Don't check for CMS root when adding hashes. Do add file paths."`
 		Verbose     bool   `short:"v" long:"verbose" description:"Show what is going on"`
+		PathFilter  string `short:"f" long:"path-filter" description:"Applies a path filter prior to diffing (e.g. vendor/magento)"`
 	}
 )
 


### PR DESCRIPTION
```
$ go run . -f vendor/magento/module-sales ~/Code/magento
Corediff 20240304-DEV loaded 2639824 precomputed hashes. (C) 2020-2023 labs@sansec.io
Using database: /home/daniel/.cache/corediff/6c8f33677d302e1847d8553877dfa6d11d4597d3.urlcache 


 X vendor/magento/module-sales/Controller/Adminhtml/Order/Create/LoadBlock.php
   17    use Magento\Framework\RegexValidator;
   40        private RegexValidator $regexValidator;
   60            RegexValidator $regexValidator = null
   72            $this->regexValidator = $regexValidator
   73                ?: ObjectManager::getInstance()->get(RegexValidator::class);
   104           if ($block && !$this->regexValidator->validateParamRegex($block)) {
   106                   __('The url has invalid characters. Please correct and try again.')


===============================================================================
 Corediff completed scanning 2441 files in /home/daniel/Code/magento
 - Files with unrecognized lines   : 1
 - Files with only recognized lines: 1586
 - Files with custom code          : 10
 - Files without code              : 844
```
